### PR TITLE
feat: Implement persistent and per-API-key rate limiting

### DIFF
--- a/BdlGusExporter/MainWindow.xaml.cs
+++ b/BdlGusExporter/MainWindow.xaml.cs
@@ -45,11 +45,11 @@ namespace BdlGusExporterWPF
             UpdateRateLimitDisplay();
         }
 
-        private bool IsUserRegistered() => chkUseApiKey.IsChecked == true && !string.IsNullOrWhiteSpace(txtApiKey.Text);
+        private string CurrentApiKey => chkUseApiKey.IsChecked == true ? txtApiKey.Text.Trim() : string.Empty;
 
         private void UpdateRateLimitDisplay()
         {
-            txtRateLimitStatus.Text = _apiRateLimiter.GetStatistics(IsUserRegistered());
+            txtRateLimitStatus.Text = _apiRateLimiter.GetStatistics(CurrentApiKey);
         }
 
         private void OnMainWindowClosed(object sender, EventArgs e)
@@ -65,13 +65,13 @@ namespace BdlGusExporterWPF
                 return cachedJson;
             }
 
-            var isRegistered = IsUserRegistered();
+            var apiKey = CurrentApiKey;
             const int maxRetries = 3;
             const int delayInMs = 1100; // 1.1 seconds to be safe
 
             for (int i = 0; i < maxRetries; i++)
             {
-                using (var lease = await _apiRateLimiter.AcquireAsync(isRegistered))
+                using (var lease = await _apiRateLimiter.AcquireAsync(apiKey))
                 {
                     if (!lease.IsAcquired)
                     {

--- a/BdlGusExporter/PersistentRateLimiter.cs
+++ b/BdlGusExporter/PersistentRateLimiter.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace BdlGusExporterWPF
+{
+    public class PersistentRateLimiter
+    {
+        private readonly string _persistencePath;
+        private Dictionary<string, RateLimiterState> _apiStates = new();
+
+        private readonly Dictionary<string, (TimeSpan, int)> _anonymousLimits;
+        private readonly Dictionary<string, (TimeSpan, int)> _registeredLimits;
+
+        private const string AnonymousUserKey = "__anonymous__";
+
+        public PersistentRateLimiter(string persistencePath = "rate_limiter_state.json")
+        {
+            _persistencePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, persistencePath);
+
+            _anonymousLimits = new Dictionary<string, (TimeSpan, int)>
+            {
+                { "15m", (TimeSpan.FromMinutes(15), 100) },
+                { "12h", (TimeSpan.FromHours(12), 1000) },
+                { "7d", (TimeSpan.FromDays(7), 10000) }
+            };
+
+            _registeredLimits = new Dictionary<string, (TimeSpan, int)>
+            {
+                { "15m", (TimeSpan.FromMinutes(15), 500) },
+                { "12h", (TimeSpan.FromHours(12), 5000) },
+                { "7d", (TimeSpan.FromDays(7), 50000) }
+            };
+        }
+
+        public void LoadState()
+        {
+            try
+            {
+                if (File.Exists(_persistencePath))
+                {
+                    var json = File.ReadAllText(_persistencePath);
+                    _apiStates = JsonSerializer.Deserialize<Dictionary<string, RateLimiterState>>(json) ?? new();
+                }
+            }
+            catch (Exception)
+            {
+                // Handle exceptions (e.g., corrupted file) by starting with a fresh state
+                _apiStates = new();
+            }
+        }
+
+        public void SaveState()
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(_apiStates, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(_persistencePath, json);
+            }
+            catch (Exception)
+            {
+                // Handle exceptions during save
+            }
+        }
+
+        public bool TryAcquire(string apiKey)
+        {
+            var userKey = string.IsNullOrWhiteSpace(apiKey) ? AnonymousUserKey : apiKey;
+            var limits = string.IsNullOrWhiteSpace(apiKey) ? _anonymousLimits : _registeredLimits;
+
+            if (!_apiStates.ContainsKey(userKey))
+            {
+                _apiStates[userKey] = new RateLimiterState();
+                foreach (var period in limits.Keys)
+                {
+                    _apiStates[userKey].RequestTimestamps[period] = new List<DateTime>();
+                }
+            }
+
+            var state = _apiStates[userKey];
+            var now = DateTime.UtcNow;
+
+            // First, check if all limits are met
+            foreach (var (period, (window, limit)) in limits)
+            {
+                if (!state.RequestTimestamps.ContainsKey(period))
+                {
+                    state.RequestTimestamps[period] = new List<DateTime>();
+                }
+
+                state.RequestTimestamps[period].RemoveAll(ts => now - ts > window);
+
+                if (state.RequestTimestamps[period].Count >= limit)
+                {
+                    return false;
+                }
+            }
+
+            // If all checks pass, add the new timestamp
+            foreach (var period in limits.Keys)
+            {
+                state.RequestTimestamps[period].Add(now);
+            }
+
+            return true;
+        }
+
+        public string GetStatistics(string apiKey)
+        {
+            var userKey = string.IsNullOrWhiteSpace(apiKey) ? AnonymousUserKey : apiKey;
+            var limits = string.IsNullOrWhiteSpace(apiKey) ? _anonymousLimits : _registeredLimits;
+
+            if (!_apiStates.ContainsKey(userKey))
+            {
+                _apiStates[userKey] = new RateLimiterState();
+                 foreach (var period in limits.Keys)
+                {
+                    _apiStates[userKey].RequestTimestamps[period] = new List<DateTime>();
+                }
+            }
+
+            var state = _apiStates[userKey];
+            var now = DateTime.UtcNow;
+            var statsBuilder = new System.Text.StringBuilder();
+            statsBuilder.Append("Dostępne limity: ");
+
+            foreach (var (period, (window, limit)) in limits)
+            {
+                if (!state.RequestTimestamps.ContainsKey(period))
+                {
+                    state.RequestTimestamps[period] = new List<DateTime>();
+                }
+
+                state.RequestTimestamps[period].RemoveAll(ts => now - ts > window);
+                var currentCount = state.RequestTimestamps[period].Count;
+                statsBuilder.Append($"| {period}: {limit - currentCount}/{limit} ");
+            }
+            return statsBuilder.ToString().TrimEnd();
+        }
+    }
+}

--- a/BdlGusExporter/RateLimiterState.cs
+++ b/BdlGusExporter/RateLimiterState.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace BdlGusExporterWPF
+{
+    public class RateLimiterState
+    {
+        [JsonInclude]
+        public Dictionary<string, List<DateTime>> RequestTimestamps { get; internal set; } = new();
+
+        public RateLimiterState()
+        {
+            // Required for JSON deserialization
+        }
+    }
+}


### PR DESCRIPTION
This change introduces a persistent rate limiting mechanism to the application. The previous in-memory rate limiting has been replaced with a custom solution that saves rate limit usage to a JSON file.

Key changes:
- Rate limits are now persisted between application sessions.
- Limits for registered users are tracked on a per-API-key basis.
- The state is saved automatically when the application is closed.

A new `PersistentRateLimiter` class handles the core logic of tracking request timestamps and serializing the state. The existing `ApiRateLimiter` has been refactored to use this new class, while still retaining a non-persistent 1-second limiter to handle rapid request bursts.