### PR TITLE
feat: Add Help menu to open help.pdf

### DIFF
--- a/BdlGusExporter/MainWindow.xaml
+++ b/BdlGusExporter/MainWindow.xaml
@@ -58,12 +58,20 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
+        <!-- Menu -->
+        <Menu Grid.Row="0" FontSize="14">
+            <MenuItem Header="_Pomoc">
+                <MenuItem x:Name="HelpMenuItem" Header="Otwórz plik pomocy" Click="HelpMenuItem_Click"/>
+            </MenuItem>
+        </Menu>
+
         <!-- Pasek klucza API -->
-        <StackPanel Orientation="Horizontal" Margin="15" Grid.Row="0">
+        <StackPanel Orientation="Horizontal" Margin="15" Grid.Row="1">
             <CheckBox x:Name="chkUseApiKey"
                       Content="Użyj klucza API"
                       VerticalAlignment="Center"
@@ -77,7 +85,7 @@
         </StackPanel>
 
         <!-- Główna część: drzewo, przyciski, lista -->
-        <Grid Grid.Row="1" Margin="15">
+        <Grid Grid.Row="2" Margin="15">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
@@ -132,7 +140,7 @@
         </Grid>
 
         <!-- Pasek postępu i status -->
-        <StatusBar Grid.Row="2" Background="#FFF0F0F0">
+        <StatusBar Grid.Row="3" Background="#FFF0F0F0">
             <StatusBarItem>
                 <ProgressBar x:Name="progressBar"
                              Width="250"

--- a/BdlGusExporter/MainWindow.xaml.cs
+++ b/BdlGusExporter/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -142,6 +143,34 @@ namespace BdlGusExporterWPF
             {
                 MessageBox.Show($"Błąd pobierania danych: {ex.Message}", "Błąd",
                                 MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void HelpMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            string helpFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "help.pdf");
+            if (File.Exists(helpFilePath))
+            {
+                try
+                {
+                    new Process
+                    {
+                        StartInfo = new ProcessStartInfo(helpFilePath)
+                        {
+                            UseShellExecute = true
+                        }
+                    }.Start();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Nie można otworzyć pliku pomocy: {ex.Message}", "Błąd",
+                                    MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+            else
+            {
+                MessageBox.Show($"Plik pomocy 'help.pdf' nie został znaleziony w folderze aplikacji.", "Brak pliku",
+                                MessageBoxButton.OK, MessageBoxImage.Information);
             }
         }
 


### PR DESCRIPTION
This change introduces a new "Help" menu to the application's main window. The menu contains an item that allows you to open a local `help.pdf` file.

- Added a `<Menu>` to `MainWindow.xaml` with a "Help" -> "Otwórz plik pomocy" structure.
- Implemented the `HelpMenuItem_Click` event handler in `MainWindow.xaml.cs`.
- The handler checks if `help.pdf` exists and opens it using the default system PDF viewer.
- If the file is not found, a message box is displayed to you.