### PR TITLE
feat: Add functionality to save and load your settings

### DIFF
--- a/BdlGusExporter/UserSettings.cs
+++ b/BdlGusExporter/UserSettings.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace BdlGusExporterWPF
+{
+    public class UserSettings
+    {
+        public bool UseApiKey { get; set; }
+        public string ApiKey { get; set; }
+        public List<string> SelectedUnitIds { get; set; }
+    }
+}


### PR DESCRIPTION
This commit introduces the ability for the application to save your settings upon exit and load them upon startup.

Key features:
- Your settings (API key, selected territorial units) are saved to a `settings.json` file when the application is closed.
- On startup, the application checks for the `settings.json` file.
- If settings are found, you are prompted with a dialog to confirm if you want to restore the settings from the previous session.
- If you confirm, the settings are loaded, restoring the API key and re-populating the list of selected territorial units.